### PR TITLE
option to create bootstrapped cov matrix of data 

### DIFF
--- a/baofit/CorrelationAnalyzer.h
+++ b/baofit/CorrelationAnalyzer.h
@@ -51,10 +51,13 @@ namespace baofit {
         // fits will be concatenated on each line. Setting fixCovariance to false means that
         // fits will use a covariance matrix that does not correctly account for double
         // counting. See likely::BinnedDataResampler::bootstrap for details.
+	// it ptname is specified, it will calculate the covariance matrix of the resampled
+	// *data* realizations and save it to the corresponding file.
         int doBootstrapAnalysis(int bootstrapTrials, int bootstrapSize, bool fixCovariance,
             likely::FunctionMinimumPtr fmin,
             likely::FunctionMinimumPtr fmin2 = likely::FunctionMinimumPtr(),
-            std::string const &refitConfig = "", std::string const &saveName = "", int nsave = 0) const;
+            std::string const &refitConfig = "", std::string const &saveName = "",
+				std::string const &ptname = "" , int nsave = 0) const;
         // Performs a jackknife analysis and returns the number of fits that failed. Set
         // jackknifeDrop to the number of observations to drop from each sample. See
         // doBootstrapAnalysis for a description of the other parameters.

--- a/src/baofit.cc
+++ b/src/baofit.cc
@@ -149,6 +149,7 @@ int main(int argc, char **argv) {
             "Number of bootstrap trials to run if a platelist was provided.")
         ("bootstrap-size", po::value<int>(&bootstrapSize)->default_value(0),
             "Size of each bootstrap trial or zero to use the number of plates.")
+        ("points-cov", "Save covariance matrix from bootstrap data samples.")
         ("jackknife-drop", po::value<int>(&jackknifeDrop)->default_value(0),
             "Number of observations to drop from each jackknife sample (zero for no jackknife analysis)")
         ("mcmc-save", po::value<int>(&mcmcSave)->default_value(0),
@@ -208,7 +209,9 @@ int main(int argc, char **argv) {
         dr9lrg(vm.count("dr9lrg")), unweighted(vm.count("unweighted")), anisotropic(vm.count("anisotropic")),
         fitEach(vm.count("fit-each")), xiHexa(vm.count("xi-hexa")),
         xiFormat(vm.count("xi-format")), decorrelated(vm.count("decorrelated")),
-        expanded(vm.count("expanded")), sectors(vm.count("sectors")), saveICov(vm.count("save-icov"));
+      expanded(vm.count("expanded")), sectors(vm.count("sectors")), saveICov(vm.count("save-icov")),
+      ptCov(vm.count("points-cov"));
+      ;
 
     // Check for the required filename parameters.
     if(0 == dataName.length() && 0 == platelistName.length()) {
@@ -456,8 +459,11 @@ int main(int argc, char **argv) {
         // Perform a bootstrap analysis, if requested.
         if(bootstrapTrials > 0) {
             std::string outName = outputPrefix + "bs.dat";
+	    std::string outPtCov = "";
+	    if (ptCov) outPtCov = outputPrefix + "ptc.dat";
+	      
             analyzer.doBootstrapAnalysis(bootstrapTrials,bootstrapSize,fixCovariance,
-                fmin,fmin2,refitConfig,outName,ndump);
+	     fmin,fmin2,refitConfig,outName, outPtCov, ndump);
         }
         // Perform a jackknife analysis, if requested.
         if(jackknifeDrop > 0) {


### PR DESCRIPTION
Hi,
this is anoter patch, not that urgent, that calculates the bootstrapped cov matrix of the _mesured datapoints_ (i.e. 1512x1512 matrix). We could compare this matrix with what the optimal estimator gives.

anze
