### PR TITLE
output MR

### DIFF
--- a/src/baofit.cc
+++ b/src/baofit.cc
@@ -437,6 +437,14 @@ int main(int argc, char **argv) {
         else {
             fmin = analyzer.fitSample(combined);
         }
+	// Dump the fit parameters and covariance matrix in machine-readable format
+	{
+	  std::string outName = outputPrefix + ".fit.out";
+	  std::ofstream out(outName.c_str());
+	  fmin->printMachineReadableToStream(out);
+	  out.close();
+	}
+
         // Dump the fit parameters in model-config format.
         {
             std::string outName = outputPrefix + "fit.config";


### PR DESCRIPTION
Another fairly trivial fix whereby I also save output in a machinereadable format so that I don't have to write script after scipt that parses log files. Really used for example when fitting e.g. correlation function.
